### PR TITLE
adding the add method to schema

### DIFF
--- a/stub/stubSchema.js
+++ b/stub/stubSchema.js
@@ -78,6 +78,13 @@ Schema.prototype.plugin = function (fn, opts) {
     return this;
 };
 
+
+Schema.prototype.add = function (opts) {
+    //add a Mongoose field type
+    return opts;
+};
+
+
 Schema.prototype.method = function (name, fn) {
    debug("defining class method: "+name);
     if ('string' != typeof name)


### PR DESCRIPTION
Hi there,

I was wandering if you could help me.
I used this in my project:
```
PageContainer.schema.add({
	translations: {type: keystone.mongoose.Schema.Types.Mixed},
});
```
but when I was testing it I would get this error:
TypeError: PageContainer.schema.add is not a function

so I was wandering if we could add the 'add' method to the schema stub.

Thanks
Nelson